### PR TITLE
Implement bookmarks bar support

### DIFF
--- a/floatingToolbar.css
+++ b/floatingToolbar.css
@@ -25,3 +25,31 @@
     --zen-element-separation: 10px !important;
   }
 }
+
+/* Bookmarks bar support */
+#PersonalToolbar:not([collapsed="true"]) {
+  background: var(--zen-colors-tertiary) !important;
+  border: 1px solid var(--zen-colors-border) !important;
+  
+  border-radius: 0 0 var(--zen-border-radius) var(--zen-border-radius);
+  border-top: none !important;
+  
+  margin-top: calc(var(--zen-border-radius) * -0.8) !important;
+  padding-top: calc(var(--zen-border-radius) * 0.8) !important;
+  
+  z-index: 2;
+  position: relative;
+}
+
+/* Separate bookmarks bar option */
+@media (-moz-bool-pref: "uc.floatingtoolbar.separate-bookmarks-bar") {
+  #PersonalToolbar:not([collapsed="true"]) {
+    background: var(--zen-colors-tertiary) !important;
+    border: 1px solid var(--zen-colors-border) !important;
+    
+    border-radius: var(--zen-border-radius);
+    
+    margin-top: 8px !important;
+    padding-top: 6px !important;
+  }
+}

--- a/preferences.json
+++ b/preferences.json
@@ -1,4 +1,5 @@
 {
     "uc.floatingtoolbar.compact.enabled": "Enable compact toolbar, similar to Smaller Compact Mode by n7itro",
-    "uc.floatingtoolbar.increase.spacing": "Increase space around edge of browser window and toolbar / tabbar"
+    "uc.floatingtoolbar.increase.spacing": "Increase space around edge of browser window and toolbar / tabbar",
+    "uc.floatingtoolbar.separate-bookmarks-bar": "Enable separate bookmarks bar"
 }


### PR DESCRIPTION
Hi. Thanks for the mod. I was kinda sad because bookmarks were just left under the toolbar so I wanted to improve it.

Disabled bookmarks bar:
![zen_yqaw6sMDyj](https://github.com/user-attachments/assets/4f444e08-08e0-44b4-b9ab-cd765d372d8f)

Enabled bookmarks bar:
![zen_iu09Z2XeQs](https://github.com/user-attachments/assets/5228e735-1e5b-44cf-bedf-7982b0b1ebf4)

Enabled bookmarks bar with enabled `uc.floatingtoolbar.separate-bookmarks-bar` option:
![zen_H2WuwemevW](https://github.com/user-attachments/assets/ba7add9d-9afa-4bdc-9d4f-b5478ac17362)
